### PR TITLE
Use productized image of tkn cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcr.io/tekton-releases/dogfooding/tkn@sha256:f69a02ef099d8915e9e4ea1b74e43b7a9309fc97cf23cb457ebf191e73491677 as tkn
+FROM registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8:0.19.0-2 as tkn
 
-FROM quay.io/openshift/origin-must-gather:4.7.0
+FROM quay.io/openshift/origin-must-gather:4.8.0
 
 # Save original gather script
 RUN mv /usr/bin/gather /usr/bin/gather_original
@@ -10,6 +10,6 @@ COPY bin/* /usr/bin/
 
 RUN chmod +x /usr/bin/gather_pipelines
 
-COPY --from=tkn /usr/local/bin/tkn /usr/local/bin/tkn
+COPY --from=tkn /usr/bin/tkn /usr/local/bin/tkn
 
 CMD ["bash", "/usr/bin/gather"]


### PR DESCRIPTION
- Bump `quay.io/openshift/origin-must-gather:4.7.0` to `quay.io/openshift/origin-must-gather:4.8.0`
- Use productized image of tkn binary