### PR TITLE
v1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ COPY --from=gather /usr/bin/openshift-must-gather /usr/bin
 COPY --from=gather /usr/bin/version /usr/bin
 COPY bin/* /usr/bin/
 
-RUN chmod +x /usr/bin/gather_pipelines
+RUN yum install --setopt=tsflags=nodocs -y jq rsync && yum clean all && rm -rf /var/cache/yum/* \
+&& chmod +x /usr/bin/gather_pipelines
 
 COPY --from=fetcher /usr/bin/oc /usr/bin/oc
 COPY --from=tkn /usr/local/bin/tkn /usr/local/bin/tkn

--- a/bin/gather_pipelines
+++ b/bin/gather_pipelines
@@ -2,68 +2,80 @@
 #
 # Run this script to collect openshift-pipelines related debug information
 
-set -eux -o pipefail
+set -eu -o pipefail
 
-COMPONENT="tekton.dev"
-BIN=oc
 LOGS_DIR=${LOGS_DIR:-must-gather-logs}
 
-# Describe and Get all api resources of component across cluster
+mkdir -p ${LOGS_DIR}
+echo "inspecting crd, clusterversion .."
+oc adm inspect $(oc get crd -o name | grep tekton) clusterversion/version --dest-dir=${LOGS_DIR}
 
-APIRESOURCES=$(${BIN} get crds -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ${COMPONENT})
-for APIRESOURCE in ${APIRESOURCES[@]}; do
-    NAMESPACES=$(${BIN} get ${APIRESOURCE} --all-namespaces=true --ignore-not-found -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
+# Describe and Get all namespaced api resources of component across cluster
+
+APIRESOURCES=$(oc get crd -o json | jq -r '.items[] | select((.spec.group | contains ("tekton.dev")) and .spec.scope=="Namespaced") | .spec.group + " " + .metadata.name + " " + .spec.names.plural')
+while read API_GROUP APIRESOURCE API_PLURAL_NAME; do 
+    echo "gather_pipelines:$LINENO] collecting ${APIRESOURCE} .."
+    NAMESPACES=$(oc get ${APIRESOURCE} --all-namespaces=true --ignore-not-found -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
     for NAMESPACE in ${NAMESPACES[@]}; do
-        mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
-        ${BIN} describe ${APIRESOURCE} -n ${NAMESPACE} >${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/describe.log
-        ${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml >${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/get.yaml
+        mkdir -p ${LOGS_DIR}/namespaces/${NAMESPACE}/${API_GROUP}/describe
+        oc describe ${APIRESOURCE} -n ${NAMESPACE} >${LOGS_DIR}/namespaces/${NAMESPACE}/${API_GROUP}/describe/${API_PLURAL_NAME}
+        oc get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml >${LOGS_DIR}/namespaces/${NAMESPACE}/${API_GROUP}/${API_PLURAL_NAME}.yaml
+    done
+done <<< $APIRESOURCES
+
+# Gather the YAML of Cluster-Scoped CR related to tekton
+
+APIRESOURCES=$(oc get crd -o json | jq -r '.items[] | select((.spec.group | contains ("tekton.dev")) and .spec.scope=="Cluster") | .spec.group + " " + .metadata.name + " " + .spec.names.plural')
+
+while read API_GROUP APIRESOURCE API_PLURAL_NAME; do 
+    mkdir -p ${LOGS_DIR}/cluster-scoped-resources/${API_GROUP}/${API_PLURAL_NAME}/describe
+    echo "gather_pipelines:$LINENO] collecting ${APIRESOURCE} .."
+    oc describe ${APIRESOURCE} >${LOGS_DIR}/cluster-scoped-resources/${API_GROUP}/${API_PLURAL_NAME}/describe/${API_PLURAL_NAME} || true
+    oc get ${APIRESOURCE} -o=yaml >${LOGS_DIR}/cluster-scoped-resources/${API_GROUP}/${API_PLURAL_NAME}/${API_PLURAL_NAME}.yaml || true
+done <<< $APIRESOURCES
+
+# Collect resources from openshift-operators, openshift-pipelines and tekton-pipelines namespaces
+echo "gather_pipelines:$LINENO] inspecting ns/openshift-operators ns/openshift-pipelines clusterroles clusterrolebindings podsecuritypolicies .."
+oc adm inspect ns/openshift-operators ns/openshift-pipelines $(oc get clusterroles,clusterrolebindings -o name | egrep -i "tekton|pipelines") $(oc get podsecuritypolicies -o name) --dest-dir=${LOGS_DIR} > /dev/null
+echo "gather_pipelines:$LINENO] inspecting clusterserviceversions subscriptions installplans .."
+oc adm inspect -n openshift-operators $(oc get csv,sub,ip -o name) --dest-dir=${LOGS_DIR} > /dev/null
+echo "gather_pipelines:$LINENO] inspecting roles rolebindings in openshift-pipelines .."
+oc adm inspect -n openshift-pipelines $(oc get roles,rolebindings -o name) --dest-dir=${LOGS_DIR} > /dev/null
+echo "gather_pipelines:$LINENO] inspecting ns/tekton-pipelines .."
+(oc adm inspect ns/tekton-pipelines --dest-dir=${LOGS_DIR} &>/dev/null) || echo "gather_pipelines:$LINENO] inspecting ns/tekton-pipelines .. failed"
+echo "gather_pipelines:$LINENO] inspecting roles rolebindings in tekton-pipelines .."
+(oc adm inspect -n tekton-pipelines $(oc get roles,rolebindings -o name) --dest-dir=${LOGS_DIR} &>/dev/null) || echo "gather_pipelines:$LINENO] inspecting roles rolebindings in tekton-pipelines .. failed"
+
+# Collect logs and yaml specs for pods referenced by TaskRuns
+NAMESPACES=$(oc get taskruns,eventlisteners --all-namespaces=true --ignore-not-found -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
+for NAMESPACE in ${NAMESPACES[@]}; do 
+    # get all the pods names referenced by taskruns
+    PODS=$(oc get po -n ${NAMESPACE} -o json | jq -r '.items[].metadata | select (.labels."app.kubernetes.io/managed-by"=="tekton-pipelines" or .labels."app.kubernetes.io/managed-by"=="EventListener")| .name' | tr  '\n' ' ')
+    mkdir -p ${LOGS_DIR}/namespaces/${NAMESPACE}/core
+    mkdir -p ${LOGS_DIR}/namespaces/${NAMESPACE}/pods
+    echo "gather_pipelines:$LINENO] collecting eventlisteners and taskrun pods in ${NAMESPACE} .."
+    eval oc get pod ${PODS} -n ${NAMESPACE} -o=yaml >${LOGS_DIR}/namespaces/${NAMESPACE}/core/pods.yaml
+    for POD in ${PODS[@]}; do 
+        echo "gather_pipelines:$LINENO] collecting logs from pod ${POD} in ${NAMESPACE} .."
+        mkdir -p ${LOGS_DIR}/namespaces/${NAMESPACE}/pods/${POD}
+        CONTAINERS=$(oc get po -n ${NAMESPACE} ${POD} -o jsonpath='{range .spec.containers[*]}{@.name}{" "}{end}')
+        for CONTAINER in ${CONTAINERS[@]}; do 
+            mkdir -p ${LOGS_DIR}/namespaces/${NAMESPACE}/pods/${POD}/${CONTAINER}/${CONTAINER}/logs
+            oc logs -n ${NAMESPACE} ${POD} -c ${CONTAINER} &> ${LOGS_DIR}/namespaces/${NAMESPACE}/pods/${POD}/${CONTAINER}/${CONTAINER}/logs/current.log
+        done
     done
 done
 
-# Gather the YAML of Cluster-Scoped CRDS provided by openshift-pipelines operator
-
-APIRESOURCES=(tektonconfigs tektoninstallersets tektonaddons tektonpipelines tektontriggers clustertasks clustertriggerbindings clusterinterceptors)
-
-for APIRESOURCE in ${APIRESOURCES[@]}; do
-    mkdir -p ${LOGS_DIR}/${APIRESOURCE}
-    ${BIN} describe ${APIRESOURCE} >${LOGS_DIR}/${APIRESOURCE}/describe.log || true
-    ${BIN} get ${APIRESOURCE} -o=yaml >${LOGS_DIR}/${APIRESOURCE}/get.yaml || true
-done
-
-# Collect pod logs from openshift-operator for openshift-pipelines-operator
-PODS=$(${BIN} get pods -n openshift-operators -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep "openshift-pipelines")
-mkdir -p ${LOGS_DIR}/openshift-operators/pods
-for POD in ${PODS[@]}; do
-    ${BIN} logs --all-containers=true -n openshift-operators ${POD} >${LOGS_DIR}/openshift-operators/pods/${POD}.log
-done
-
-# Collect pod logs, describe & get of api-resources in openshift-pipelines and tekton-pipelines namespace
-
-NAMESPACES=(openshift-pipelines tekton-pipelines)
-APIRESOURCES=(configmaps pods roles rolebindings clusterrole clusterrolebindings serviceaccounts services events podsecuritypolicies poddisruptionbudgets)
-
-for NAMESPACE in ${NAMESPACES[@]}; do
-    PODS=$(${BIN} get pods -n ${NAMESPACE} -o jsonpath="{.items[*].metadata.name}")
-    mkdir -p ${LOGS_DIR}/${NAMESPACE}/pods
-    for POD in ${PODS[@]}; do
-        ${BIN} logs --all-containers=true -n ${NAMESPACE} ${POD} >${LOGS_DIR}/${NAMESPACE}/pods/${POD}.log || true
-    done
-
-    for APIRESOURCE in ${APIRESOURCES[@]}; do
-        mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
-        ${BIN} describe ${APIRESOURCE} -n ${NAMESPACE} >${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/describe.log || true
-        ${BIN} get ${APIRESOURCE} -n ${NAMESPACE} -o=yaml >${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/get.yaml || true
-    done
-done
-
+# Collect indipendent logs for eventlistener, taskruns and pipelineruns
 APIRESOURCES=(eventlistener taskrun pipelinerun)
 for APIRESOURCE in ${APIRESOURCES[@]}; do
-    NAMESPACES=$(${BIN} get ${APIRESOURCE} --all-namespaces=true --ignore-not-found -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
+    NAMESPACES=$(oc get ${APIRESOURCE} --all-namespaces=true --ignore-not-found -o jsonpath='{range .items[*]}{@.metadata.namespace}{"\n"}{end}' | uniq)
     for NAMESPACE in ${NAMESPACES[@]}; do
-        mkdir -p ${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}
-        RESOURCES=$(${BIN} get ${APIRESOURCE} --namespace=${NAMESPACE} --ignore-not-found -o jsonpath='{range .items[*]}{@.metadata.name}{"\n"}{end}')
+        mkdir -p ${LOGS_DIR}/namespaces/${NAMESPACE}/${APIRESOURCE}/logs
+        RESOURCES=$(oc get ${APIRESOURCE} --namespace=${NAMESPACE} --ignore-not-found -o jsonpath='{range .items[*]}{@.metadata.name}{"\n"}{end}')
         for RESOURCE in ${RESOURCES[@]}; do
-            tkn ${APIRESOURCE} logs ${RESOURCE} -n ${NAMESPACE} >${LOGS_DIR}/${NAMESPACE}/${APIRESOURCE}/${RESOURCE}.log
+            echo "gather_pipelines:$LINENO] collecting ${APIRESOURCE} logs in ${NAMESPACE} .."
+            tkn ${APIRESOURCE} logs ${RESOURCE} -n ${NAMESPACE} >${LOGS_DIR}/namespaces/${NAMESPACE}/${APIRESOURCE}/logs/${RESOURCE}.log
         done
     done
 done


### PR DESCRIPTION
## Summary
These modifications will allow the pipelines' must-gather to have a structure conformed with the standard must-gather.
By doing so the engineers will be able to inspect the must-gather using the [`omc`](https://github.com/gmeghnag/omc) tool and improve the troubleshooting.

## What's changed?
- Modified the script to let the must-gather structure be compatible with the standard must-gather;
- Implemented commands to allow dynamic gathering of tekton-related resources (see lines 15, 28);
- Extensive usage of `oc adm inspect` to get most of the resources;
- Collected pods related to TaskRuns and EventListeners;
- Improved script verbosity during execution (removed `set -x`);
- Added `jq` and `rsync` binaries as Dockerfile image dependencies.

## Test it 
It is possible to test the new image by running `oc adm must-gather --image=quay.io/gmeghnag/tekton-must-gather:v1.0 `:
```
$ oc adm must-gather --image=quay.io/gmeghnag/tekton-must-gather:v1.0                                                                          
[must-gather      ] OUT Using must-gather plug-in image: quay.io/gmeghnag/tekton-must-gather:v1.0
When opening a support case, bugzilla, or issue please include the following summary data along with any other requested information.
ClusterID: 65b66f40-9b2b-41e9-a145-70bbaf401359
ClusterVersion: Stable at "4.10.30"
ClusterOperators:
	All healthy and stable


[must-gather      ] OUT namespace/openshift-must-gather-txjpn created
[must-gather      ] OUT clusterrolebinding.rbac.authorization.k8s.io/must-gather-6psrg created
[must-gather      ] OUT pod for plug-in image quay.io/gmeghnag/tekton-must-gather:v1.0 created
[must-gather-q7c5z] POD 2022-11-04T12:09:47.788730855Z inspecting crd, clusterversion ..
[must-gather-q7c5z] POD 2022-11-04T12:09:51.646689128Z Wrote inspect data to /must-gather.
[must-gather-q7c5z] POD 2022-11-04T12:09:52.265307632Z gather_pipelines:17] collecting conditions.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:09:52.722864761Z gather_pipelines:17] collecting eventlisteners.triggers.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:09:54.363658774Z gather_pipelines:17] collecting pipelineresources.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:09:54.700758741Z gather_pipelines:17] collecting pipelineruns.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:09:55.707873635Z gather_pipelines:17] collecting pipelines.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:09:57.622315586Z gather_pipelines:17] collecting runs.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:09:57.941898196Z gather_pipelines:17] collecting taskruns.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:09:58.917254551Z gather_pipelines:17] collecting tasks.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:09:59.912931106Z gather_pipelines:17] collecting triggerbindings.triggers.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:00.235942543Z gather_pipelines:17] collecting triggers.triggers.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:00.563677332Z gather_pipelines:17] collecting triggertemplates.triggers.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:01.511968491Z gather_pipelines:32] collecting clusterinterceptors.triggers.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:02.266049605Z gather_pipelines:32] collecting clustertasks.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:03.892871111Z gather_pipelines:32] collecting clustertriggerbindings.triggers.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:04.903101976Z gather_pipelines:32] collecting tektonaddons.operator.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:05.624749862Z gather_pipelines:32] collecting tektonconfigs.operator.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:06.274678357Z gather_pipelines:32] collecting tektoninstallersets.operator.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:07.366214255Z gather_pipelines:32] collecting tektonpipelines.operator.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:08.045208769Z gather_pipelines:32] collecting tektontriggers.operator.tekton.dev ..
[must-gather-q7c5z] POD 2022-11-04T12:10:08.725896941Z gather_pipelines:38] inspecting ns/openshift-operators ns/openshift-pipelines clusterroles clusterrolebindings podsecuritypolicies ..

...
```

## How to inspect the resources?
It's possible to inspect the must-gather resources using the [`omc`](https://github.com/gmeghnag/omc) tool:
```
$ omc use must-gather.local.1526438520016972609
$ omc get taskruns -A
NAMESPACE   NAME                                        SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
devops      greet-someone-run-8tcd2                     True        Succeeded   Unknown     Unknown
devops      greetings-run-6npct-first-greeting-tprb2    True        Succeeded   Unknown     Unknown
devops      greetings-run-6npct-second-greeting-bhf9z   True        Succeeded   Unknown     Unknown

$ omc get pods -n devops
NAME                                                  READY   STATUS      RESTARTS   AGE
el-listener-f7c59bb76-gpd65                           1/1     Running     1          2h17m
greet-someone-run-8tcd2-pod-4mfdz                     0/1     Completed   0          18h
greetings-run-6npct-first-greeting-tprb2-pod-4wlcw    0/1     Completed   0          12h
greetings-run-6npct-second-greeting-bhf9z-pod-2m9dn   0/1     Completed   0          12h

$ omc logs -n devops greet-someone-run-8tcd2-pod-4mfdz  
Hello Redhat
+ echo 'Hello Redhat'

$ omc get crd
NAME                                         CREATED AT
clusterinterceptors.triggers.tekton.dev      2022-11-03T14:00:46Z
clustertasks.tekton.dev                      2022-11-03T13:59:53Z
clustertriggerbindings.triggers.tekton.dev   2022-11-03T14:00:46Z
conditions.tekton.dev                        2022-11-03T13:59:53Z
eventlisteners.triggers.tekton.dev           2022-11-03T14:00:47Z
pipelineresources.tekton.dev                 2022-11-03T13:59:53Z
pipelineruns.tekton.dev                      2022-11-03T13:59:53Z
pipelines.tekton.dev                         2022-11-03T13:59:53Z
runs.tekton.dev                              2022-11-03T13:59:53Z
taskruns.tekton.dev                          2022-11-03T13:59:54Z
tasks.tekton.dev                             2022-11-03T13:59:54Z
tektonaddons.operator.tekton.dev             2022-11-03T13:59:23Z
tektonconfigs.operator.tekton.dev            2022-11-03T13:59:22Z
tektoninstallersets.operator.tekton.dev      2022-11-03T13:59:22Z
tektonpipelines.operator.tekton.dev          2022-11-03T13:59:22Z
tektontriggers.operator.tekton.dev           2022-11-03T13:59:23Z
triggerbindings.triggers.tekton.dev          2022-11-03T14:00:47Z
triggers.triggers.tekton.dev                 2022-11-03T14:00:47Z
triggertemplates.triggers.tekton.dev         2022-11-03T14:00:47Z

$ omc get tektoninstallersets.operator.tekton.dev
NAME                                     READY   REASON
addon-clustertasks-6p957                 True
addon-consolecli-r9xqh                   True
addon-openshift-fqngh                    True
addon-pipelines-scn9g                    True
addon-triggers-fmz8c                     True
addon-versioned-clustertasks-1-6-lx5z4   True
pipeline-v8cpg                           True
postpipeline-x9zjb                       True
prepipeline-dpffc                        True
rhosp-rbac-4rsfh                         True
trigger-j2znk                            True
validating-mutating-webhoook-qttkv       True

$ omc get tektoninstallersets.operator.tekton.dev -o yaml | head
apiVersion: v1
items:
- apiVersion: v1
  items:
  - apiVersion: operator.tekton.dev/v1alpha1
    kind: TektonInstallerSet
    metadata:
      annotations:
        operator.tekton.dev/last-applied-hash: e5e4edace7f457267f7456b1f8dd6d4ae12e96b13047229908bd54d6440ce059
        operator.tekton.dev/target-namespace: openshift-pipelines
```
