### PR TITLE
.github/workflows: update how we tag latest.

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -37,15 +37,10 @@ jobs:
           # If this is git tag, use the tag name as a docker tag
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
-
-          # If the VERSION looks like a version number, assume that
-          # this is the most recent version of the image and also
-          # tag it 'latest'.
-          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            # It is a tag (release), let's also build latest
             TAGS="$TAGS,${DOCKER_IMAGE}:latest"
           fi
+          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
 
           # Set output parameters.
           echo ::set-output name=tags::${TAGS}


### PR DESCRIPTION
Only tag latest on a build from a git tag.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
